### PR TITLE
Fixed sending login packet to non-existent player

### DIFF
--- a/src/main/java/net/silentchaos512/scalinghealth/resources/mechanics/SHMechanics.java
+++ b/src/main/java/net/silentchaos512/scalinghealth/resources/mechanics/SHMechanics.java
@@ -46,7 +46,7 @@ public record SHMechanics(PlayerMechanics playerMechanics, ItemMechanics itemMec
         else {
             for (ServerPlayer player : event.getPlayerList().getPlayers()) {
                 Network.channel.sendTo(new SHMechanicsPacket(SHMechanicListener.getInstance()), player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
-                Network.channel.sendTo(new ClientLoginMessage(SHDifficulty.areaMode(), (float) SHDifficulty.maxValue()), event.getPlayer().connection.connection, NetworkDirection.PLAY_TO_CLIENT);
+                Network.channel.sendTo(new ClientLoginMessage(SHDifficulty.areaMode(), (float) SHDifficulty.maxValue()), player.connection.connection, NetworkDirection.PLAY_TO_CLIENT);
             }
         }
     }


### PR DESCRIPTION
This is what was causing issues like #418

(needs to be applied to 1.18 branch as well)